### PR TITLE
Add exception for ModuleRestockLaunchClamp

### DIFF
--- a/WorldStabilizer/WorldStabilizer.cs
+++ b/WorldStabilizer/WorldStabilizer.cs
@@ -764,6 +764,8 @@ namespace WorldStabilizer
 			foreach (Part p in v.parts) {
 				if (p.Modules.Contains ("LaunchClamp"))
 					return true;
+				if (p.Modules.Contains ("ModuleRestockLaunchClamp"))
+					return true;
 				if (p.Modules.Contains ("FlagSite"))
 					return true;
 				if (excludeVessels.Contains(v.GetName())) {


### PR DESCRIPTION
ReStock replaces the stock launch clamp module with its own that extends the stock version. Since the module has a different name it isnt being detected by World Stabilizer